### PR TITLE
Fix pyOCD/README link

### DIFF
--- a/Docs/Debugging/pyOCD.md
+++ b/Docs/Debugging/pyOCD.md
@@ -18,7 +18,7 @@ The interface chip implements CMSIS-DAP. To drive the CMSIS-DAP interface chip o
 ![](../Debugging/Images/PyOCD1.png)
 </span>
 
-To install pyOCD, follow the [instructions](https://github.com/mbedmicro/pyOCD/blob/master/README.md#installation) to get the external USB libraries pyOCD relies on.
+To install pyOCD, follow the [instructions](https://github.com/mbedmicro/pyOCD/blob/master/README.rst#installation) to get the external USB libraries pyOCD relies on.
 
 <span class="notes">**Notes:** 
 <br />a. You'll need to run ``setup.py`` for both the USB libraries and pyOCD.


### PR DESCRIPTION
Tiny PR just to fix a link pointing to the wrong file extension.
